### PR TITLE
feat(assignment rule): adds role field and all option to assignment rule

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -5,26 +5,12 @@ frappe.ui.form.on('Assignment Rule', {
 	refresh: function(frm) {
 		// refresh description
 		frm.events.rule(frm);
-		frm.events.role(frm);
 	},
 	rule: function(frm) {
 		if (frm.doc.rule === 'Round Robin') {
 			frm.get_field('rule').set_description(__('Assign one by one, in sequence'));
-		} else if (frm.doc.rule === 'Load Balancing') {
-			frm.get_field('rule').set_description(__('Assign to the one who has the least assignments'));
-		} else if (frm.doc.rule === 'All') {
-			frm.get_field('rule').set_description(__('Assign to all users selected'));
-		}
-	},
-	role: function(frm) {
-		if (frm.doc.role) {
-			frm.set_df_property('users', 'reqd', 0);
-			frm.set_df_property('exclude_users', 'hidden', 0);
-			frm.get_field('role').set_description(__('Assign to all users with this Role in addition to users listed in the User field'));
 		} else {
-			frm.set_df_property('users', 'reqd', 1);
-			frm.set_df_property('exclude_users', 'hidden', 1);
-			frm.get_field('role').set_description(__(''));
+			frm.get_field('rule').set_description(__('Assign to the one who has the least assignments'));
 		}
 	}
 });

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -5,12 +5,26 @@ frappe.ui.form.on('Assignment Rule', {
 	refresh: function(frm) {
 		// refresh description
 		frm.events.rule(frm);
+		frm.events.role(frm);
 	},
 	rule: function(frm) {
 		if (frm.doc.rule === 'Round Robin') {
 			frm.get_field('rule').set_description(__('Assign one by one, in sequence'));
-		} else {
+		} else if (frm.doc.rule === 'Load Balancing') {
 			frm.get_field('rule').set_description(__('Assign to the one who has the least assignments'));
+		} else if (frm.doc.rule === 'All') {
+			frm.get_field('rule').set_description(__('Assign to all users selected'));
+		}
+	},
+	role: function(frm) {
+		if (frm.doc.role) {
+			frm.set_df_property('users', 'reqd', 0);
+			frm.set_df_property('exclude_users', 'hidden', 0);
+			frm.get_field('role').set_description(__('Assign to all users with this Role in addition to users listed in the User field'));
+		} else {
+			frm.set_df_property('users', 'reqd', 1);
+			frm.set_df_property('exclude_users', 'hidden', 1);
+			frm.get_field('role').set_description(__(''));
 		}
 	}
 });

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.json
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -23,7 +23,10 @@
   "assign_to_users_section",
   "rule",
   "users",
-  "last_user"
+  "last_user",
+  "column_break_17",
+  "role",
+  "exclude_users"
  ],
  "fields": [
   {
@@ -91,15 +94,14 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Rule",
-   "options": "Round Robin\nLoad Balancing",
+   "options": "Round Robin\nLoad Balancing\nAll",
    "reqd": 1
   },
   {
    "fieldname": "users",
    "fieldtype": "Table MultiSelect",
    "label": "Users",
-   "options": "Assignment Rule User",
-   "reqd": 1
+   "options": "Assignment Rule User"
   },
   {
    "fieldname": "last_user",
@@ -129,9 +131,26 @@
    "label": "Assignment Days",
    "options": "Assignment Rule Day",
    "reqd": 1
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Link",
+   "label": "Role",
+   "options": "Role"
+  },
+  {
+   "fieldname": "column_break_17",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "exclude_users",
+   "fieldtype": "Table MultiSelect",
+   "hidden": 1,
+   "label": "Exclude Users",
+   "options": "Assignment Rule User"
   }
  ],
- "modified": "2019-09-25 14:52:12.214514",
+ "modified": "2020-07-17 02:33:22.643850",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Assignment Rule",

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.json
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -23,10 +23,7 @@
   "assign_to_users_section",
   "rule",
   "users",
-  "last_user",
-  "column_break_17",
-  "role",
-  "exclude_users"
+  "last_user"
  ],
  "fields": [
   {
@@ -94,14 +91,15 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Rule",
-   "options": "Round Robin\nLoad Balancing\nAll",
+   "options": "Round Robin\nLoad Balancing",
    "reqd": 1
   },
   {
    "fieldname": "users",
    "fieldtype": "Table MultiSelect",
    "label": "Users",
-   "options": "Assignment Rule User"
+   "options": "Assignment Rule User",
+   "reqd": 1
   },
   {
    "fieldname": "last_user",
@@ -131,26 +129,9 @@
    "label": "Assignment Days",
    "options": "Assignment Rule Day",
    "reqd": 1
-  },
-  {
-   "fieldname": "role",
-   "fieldtype": "Link",
-   "label": "Role",
-   "options": "Role"
-  },
-  {
-   "fieldname": "column_break_17",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "exclude_users",
-   "fieldtype": "Table MultiSelect",
-   "hidden": 1,
-   "label": "Exclude Users",
-   "options": "Assignment Rule User"
   }
  ],
- "modified": "2020-07-17 02:33:22.643850",
+ "modified": "2019-09-25 14:52:12.214514",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Assignment Rule",

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -19,7 +19,7 @@ class AssignmentRule(Document):
 			repeated_days = get_repeated(assignment_days)
 			frappe.throw(_("Assignment Day {0} has been repeated.".format(frappe.bold(repeated_days))))
 		if not self.role and not self.users:
-			frappe.throw(_("Please select users or a role for assignment"))
+			frappe.throw(_("Please select Users or Role for assignment"))
 
 	def on_update(self): # pylint: disable=no-self-use
 		frappe.cache_manager.clear_doctype_map('Assignment Rule', self.name)
@@ -62,8 +62,8 @@ class AssignmentRule(Document):
 				notify = True
 			))
 
-			# set for reference in round robin
-			self.db_set('last_user', user)
+		# set for reference in round robin
+		self.db_set('last_user', users[-1])
 
 	def clear_assignment(self, doc):
 		'''Clear assignments'''
@@ -91,7 +91,7 @@ class AssignmentRule(Document):
 				user_list.remove(user.user)
 
 		if self.rule == 'All':
-			return user_list			
+			return user_list
 		elif self.rule == 'Round Robin':
 			return [self.get_user_round_robin(user_list)]
 		elif self.rule == 'Load Balancing':


### PR DESCRIPTION
Changes made:
- Added Role and Exclude Users field to Assignment Rule
- Added All option to Rule field
- Made Users field non-mandatory
- Role selected will add all users having that Role to the list of users to be assigned to along with users from the User field and excluding users from the Exclude Users field
- Selecting All as a roll will assign the selected document to all the Users

![image](https://user-images.githubusercontent.com/33743873/87804159-19ec5600-c871-11ea-8269-4ab446584fc7.png)
