### PR TITLE
feat: enables, disables and deletes notification settings when a user is modified [CU-j8wutt]

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -129,7 +129,7 @@ class User(Document):
 
 		# enable notifications if the user has been enabled
 		if cint(self.enabled):
-			enable_disable_notifications(self.name, True)
+			enable_disable_notifications(self.name, enabled=True)
 
 	def add_system_manager_role(self):
 		# if adding system manager, do nothing

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -8,7 +8,7 @@ from frappe.utils import cint, flt, has_gravatar, escape_html, format_datetime, 
 from frappe import throw, msgprint, _
 from frappe.utils.password import update_password as _update_password
 from frappe.desk.notifications import clear_notifications
-from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings
+from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings, enable_disable_notifications
 from frappe.utils.user import get_system_managers
 from bs4 import BeautifulSoup
 import frappe.permissions
@@ -120,10 +120,16 @@ class User(Document):
 
 		if not cint(self.enabled):
 			self.a_system_manager_should_exist()
+			# disable notifications if the user has been disabled
+			enable_disable_notifications(self.name, False)
 
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):
 			frappe.local.login_manager.logout(user=self.name)
+
+		# enable notifications if the user has been enabled
+		if cint(self.enabled):
+			enable_disable_notifications(self.name, True)
 
 	def add_system_manager_role(self):
 		# if adding system manager, do nothing
@@ -333,6 +339,10 @@ class User(Document):
 		frappe.db.sql("""update `tabContact`
 			set `user`=null
 			where `user`=%s""", (self.name))
+
+		# delete notification settings
+		frappe.db.sql("""DELETE FROM `tabNotification Settings` WHERE `name`=%s""", 
+			(self.name))
 
 
 	def before_rename(self, old_name, new_name, merge=False):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -341,8 +341,7 @@ class User(Document):
 			where `user`=%s""", (self.name))
 
 		# delete notification settings
-		frappe.db.sql("""DELETE FROM `tabNotification Settings` WHERE `name`=%s""", 
-			(self.name))
+		frappe.delete_doc("Notification Settings", self.name, ignore_permissions=True)
 
 
 	def before_rename(self, old_name, new_name, merge=False):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -121,7 +121,7 @@ class User(Document):
 		if not cint(self.enabled):
 			self.a_system_manager_should_exist()
 			# disable notifications if the user has been disabled
-			enable_disable_notifications(self.name, False)
+			enable_disable_notifications(self.name, enabled=False)
 
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -41,6 +41,10 @@ def create_notification_settings(user):
 		_doc.insert(ignore_permissions=True)
 		frappe.db.commit()
 
+def enable_disable_notifications(user, enabled):
+	frappe.db.set_value("Notification Settings", user, 'enabled', enabled)
+	frappe.db.commit()
+
 
 @frappe.whitelist()
 def get_subscribed_documents():

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -42,7 +42,7 @@ def create_notification_settings(user):
 		frappe.db.commit()
 
 def enable_disable_notifications(user, enabled):
-	frappe.db.set_value("Notification Settings", user, 'enabled', enabled)
+	frappe.set_value("Notification Settings", user, 'enabled', enabled)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -43,7 +43,6 @@ def create_notification_settings(user):
 
 def enable_disable_notifications(user, enabled):
 	frappe.db.set_value("Notification Settings", user, 'enabled', enabled)
-	frappe.db.commit()
 
 
 @frappe.whitelist()

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -318,7 +318,10 @@ def send_summary(timespan):
 
 	from_date = getdate(from_date)
 	to_date = getdate()
-	all_users = [user.email for user in get_enabled_system_users()]
+
+	# select only those users that have energy point email notifications enabled
+	all_users = [user.email for user in get_enabled_system_users() if
+		is_email_notifications_enabled_for_type(user.name, 'Energy Point')]
 
 	frappe.sendmail(
 			subject='{} energy points summary'.format(timespan),


### PR DESCRIPTION
Changes made:
- disables/enables notification settings for a user when the user is disabled/enabled
- deletes the Notification Settings doc for a user when the user is deleted
- added check to sending Energy Point Summary emails to check if user has notifications enabled for energy points