### PR TITLE
fix: handle IMAP abort error in email

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -286,7 +286,8 @@ class EmailServer:
 			self.seen_status.update({ uid: "UNSEEN" })
 
 	def has_login_limit_exceeded(self, e):
-		return "-ERR Exceeded the login limit" in strip(cstr(e.message))
+		error = getattr(e, "message", e)
+		return "-ERR Exceeded the login limit" in strip(cstr(error))
 
 	def is_temporary_system_problem(self, e):
 		messages = (


### PR DESCRIPTION
[Sentry Error](https://sentry.io/organizations/parsimony/issues/2187780290/?project=5454205&query=is%3Aunresolved)