### PR TITLE
fix: check if attachment exists before uploading file

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -109,13 +109,14 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		}
 
 		// validation hack: get_values will check for missing data
-		let isvalid = super.get_values(this.allow_incomplete);
+		let doc_values = super.get_values(this.allow_incomplete);
 
-		if (!isvalid) return;
+		if (!doc_values) return;
 
 		if (window.saving) return;
 		let for_payment = Boolean(this.accept_payment && !this.doc.paid);
 
+		Object.assign(this.doc, doc_values);
 		this.doc.doctype = this.doc_type;
 		this.doc.web_form_name = this.name;
 

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -141,7 +141,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 					frappe.web_form.events.trigger('after_save');
 					this.after_save && this.after_save();
 					// args doctype and docname added to link doctype in file manager
-					if (is_new) {
+					if (is_new && response.message.attachment) {
 						frappe.call({
 							type: 'POST',
 							method: "frappe.handler.upload_file",


### PR DESCRIPTION
Also pull a fix from v12-hotfix that pulls data from webform tables

Co-authored-by: Fumin <awawfumin@gmail.com>
Co-authored-by: Shivam Mishra <scmmishra@users.noreply.github.com>