### PR TITLE
fix: adds check before enabling notification settings

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -42,7 +42,8 @@ def create_notification_settings(user):
 		frappe.db.commit()
 
 def enable_disable_notifications(user, enabled):
-	frappe.set_value("Notification Settings", user, 'enabled', enabled)
+	if frappe.db.exists("Notification Settings", user):
+		frappe.set_value("Notification Settings", user, 'enabled', enabled)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Changes made:
- added check to see if Notification Settings exist for the user before enabling or disabling it