### PR TITLE
refactor: updates notification toggle function name and trigger condition

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -8,7 +8,7 @@ from frappe.utils import cint, flt, has_gravatar, escape_html, format_datetime, 
 from frappe import throw, msgprint, _
 from frappe.utils.password import update_password as _update_password
 from frappe.desk.notifications import clear_notifications
-from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings, enable_disable_notifications
+from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings, toggle_notifications
 from frappe.utils.user import get_system_managers
 from bs4 import BeautifulSoup
 import frappe.permissions
@@ -121,15 +121,14 @@ class User(Document):
 		if not cint(self.enabled):
 			self.a_system_manager_should_exist()
 			# disable notifications if the user has been disabled
-			enable_disable_notifications(self.name, enabled=False)
+			toggle_notifications(self.name, enable=False)
+		else:
+			# enable notifications if the user has been enabled
+			toggle_notifications(self.name, enable=True)
 
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):
 			frappe.local.login_manager.logout(user=self.name)
-
-		# enable notifications if the user has been enabled
-		if cint(self.enabled):
-			enable_disable_notifications(self.name, enabled=True)
 
 	def add_system_manager_role(self):
 		# if adding system manager, do nothing

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -120,15 +120,13 @@ class User(Document):
 
 		if not cint(self.enabled):
 			self.a_system_manager_should_exist()
-			# disable notifications if the user has been disabled
-			toggle_notifications(self.name, enable=False)
-		else:
-			# enable notifications if the user has been enabled
-			toggle_notifications(self.name, enable=True)
 
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):
 			frappe.local.login_manager.logout(user=self.name)
+
+		# toggle notifications based on the user's status
+		toggle_notifications(self.name, enable=cint(self.enabled))
 
 	def add_system_manager_role(self):
 		# if adding system manager, do nothing

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -44,7 +44,7 @@ def create_notification_settings(user):
 
 def toggle_notifications(user, enable=False):
 	if frappe.db.exists("Notification Settings", user):
-		frappe.set_value("Notification Settings", user, 'enabled', enable)
+		frappe.db.set_value("Notification Settings", user, 'enabled', enable)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -41,9 +41,10 @@ def create_notification_settings(user):
 		_doc.insert(ignore_permissions=True)
 		frappe.db.commit()
 
-def enable_disable_notifications(user, enabled):
+
+def toggle_notifications(user, enable=False):
 	if frappe.db.exists("Notification Settings", user):
-		frappe.set_value("Notification Settings", user, 'enabled', enabled)
+		frappe.set_value("Notification Settings", user, 'enabled', enable)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Changes made:
- changed function name from `enable_disable_notifications` to `toggle_notifications`
- combined `if` condition into `if-else` to prevent duplicate check