### PR TITLE
fix: remove exception logging on the frontend to prevent sensitive data leak

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -347,11 +347,11 @@ frappe.request.cleanup = function(opts, r) {
 		}
 
 		// show errors
-		if(r.exc) {
+		if (r.exc && frappe.boot.developer_mode) {
 			r.exc = JSON.parse(r.exc);
-			if(r.exc instanceof Array) {
-				$.each(r.exc, function(i, v) {
-					if(v) {
+			if (r.exc instanceof Array) {
+				$.each(r.exc, function (i, v) {
+					if (v) {
 						console.log(v);
 					}
 				})
@@ -429,9 +429,6 @@ frappe.request.report_error = function(xhr, request_opts) {
 			'<h5>Route</h5>',
 			'<pre>' + frappe.get_route_str() + '</pre>',
 			'<hr>',
-			'<h5>Error Report</h5>',
-			'<pre>' + exc + '</pre>',
-			'<hr>',
 			'<h5>Request Data</h5>',
 			'<pre>' + JSON.stringify(request_opts, null, "\t") + '</pre>',
 			'<hr>',
@@ -476,7 +473,6 @@ frappe.request.report_error = function(xhr, request_opts) {
 		}
 
 		let parts = strip(exc).split('\n');
-
 		frappe.error_dialog.$body.html(parts[parts.length - 1]);
 		frappe.error_dialog.show();
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -107,9 +107,6 @@ def make_logs(response = None):
 	if not response:
 		response = frappe.local.response
 
-	if frappe.error_log:
-		response['exc'] = json.dumps([frappe.utils.cstr(d["exc"]) for d in frappe.local.error_log])
-
 	if frappe.local.message_log:
 		response['_server_messages'] = json.dumps([frappe.utils.cstr(d) for
 			d in frappe.local.message_log])


### PR DESCRIPTION
This may be taken as opinionated by Frappe, but should we make it upstream anyway?

Should we consider putting this behind a toggle, like `developer_mode` instead? That might be more palatable for general use.