### PR TITLE
fix: lock iPython to 7.16.0

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -449,7 +449,7 @@ def console(context):
 	frappe.connect()
 	frappe.local.lang = frappe.db.get_default("lang")
 	import IPython
-	IPython.embed(display_banner = "")
+	IPython.embed(colors="Neutral", display_banner = "")
 
 @click.command('run-tests')
 @click.option('--app', help="For App")

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ googlemaps==3.1.1
 gunicorn==19.10.0
 html2text==2016.9.19
 html5lib==1.0.1
-ipython==5.8.0
+ipython~=7.16.1
 Jinja2==2.11.3
 ldap3==2.7
 markdown2==2.3.9


### PR DESCRIPTION
Required for https://github.com/ParsimonyGit/parsimony/pull/223.