### PR TITLE
fix: ux improvements on doctype layout [CU-3p0m202]

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -190,12 +190,8 @@ frappe.router = {
 		} else {
 			route = ["List", doctype_route.doctype, "List"];
 		}
-
-		if (doctype_route.doctype_layout) {
-			// set the layout
-			this.doctype_layout = doctype_route.doctype_layout;
-		}
-
+		// reset the layout to avoid using incorrect views
+		this.doctype_layout = doctype_route.doctype_layout;
 		return route;
 	},
 


### PR DESCRIPTION
**Changes:**
- Moving a row now correctly triggers an unsaved state
- Selecting a document type no longer resets the "Name" field
- Reset doctype layout reference in router when page changes