### PR TITLE
fix: allow headers for axios-interceptor-cache

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -183,9 +183,11 @@ def set_cors_headers(response):
 			"Access-Control-Allow-Headers": (
 				"Authorization,DNT,X-Mx-ReqToken,"
 				"Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,"
-				"Cache-Control,Content-Type",
+				"Cache-Control,Content-Type,X-Frappe-Site-Name,",
 				# https://docs.sentry.io/platforms/javascript/performance/connect-services/
-				"baggage,sentry-trace"
+				"baggage,sentry-trace,",
+				# https://axios-cache-interceptor.js.org/config/request-specifics#cache-cachetakeover
+				"pragma,expires"
 			),
 		}
 	)


### PR DESCRIPTION
Required for https://github.com/ParsimonyGit/parsimony_sop/pull/176.